### PR TITLE
Keycloak authentication updates

### DIFF
--- a/cmd/kthcloud-cli/cli_login.go
+++ b/cmd/kthcloud-cli/cli_login.go
@@ -3,7 +3,6 @@ package main
 import (
 	"kthcloud-cli/internal/model"
 	"kthcloud-cli/pkg/auth"
-	"net/url"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -14,25 +13,22 @@ var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Log in to kthcloud using Keycloak and retrieve the authentication token",
 	Run: func(cmd *cobra.Command, args []string) {
-		clientID := viper.GetString("client-id")
-		clientSecret := viper.GetString("client-secret")
-		authURL := viper.GetString("auth-url")
-		tokenURL := viper.GetString("token-url")
-		redirectURI := viper.GetString("redirect-uri")
+		//clientID := viper.GetString("client-id")
+		//clientSecret := viper.GetString("client-secret")
+		//authURL := viper.GetString("auth-url")
+		//tokenURL := viper.GetString("token-url")
+		//redirectURI := viper.GetString("redirect-uri")
 
-		err := auth.OpenBrowser(authURL + "?client_id=" + clientID + "&redirect_uri=" + url.QueryEscape(redirectURI) + "&response_type=code&scope=openid")
+		//url := authURL + "?client_id=" + clientID + "&redirect_uri=" + url.QueryEscape(redirectURI) + "&response_type=code&scope=openid"
+
+		err := auth.OpenBrowser("http://localhost:3000")
 		if err != nil {
 			log.Fatalf("Failed to open browser: %v", err)
 		}
 
-		code, err := auth.StartLocalServer()
+		authSession, err := auth.StartLocalServer()
 		if err != nil {
 			log.Fatalf("Failed to start local server: %v", err)
-		}
-
-		authSession, err := auth.GetAuthSession(code, clientID, clientSecret, tokenURL, redirectURI)
-		if err != nil {
-			log.Fatalf("Failed to get auth session: %v", err)
 		}
 
 		session := model.NewSession(authSession)

--- a/internal/compose/conv.go
+++ b/internal/compose/conv.go
@@ -68,7 +68,7 @@ func serviceToDepl(service model.Service, name string, projectDir string) *body.
 		Name:       name,
 		CpuCores:   util.Float64Pointer(0.2),
 		RAM:        util.Float64Pointer(0.5),
-		Replicas:   util.IntPointer(0),
+		Replicas:   util.IntPointer(1),
 		Envs:       envs,
 		Image:      &service.Image,
 		Visibility: visibility,

--- a/internal/compose/conv.go
+++ b/internal/compose/conv.go
@@ -68,7 +68,7 @@ func serviceToDepl(service model.Service, name string, projectDir string) *body.
 		Name:       name,
 		CpuCores:   util.Float64Pointer(0.2),
 		RAM:        util.Float64Pointer(0.5),
-		Replicas:   util.IntPointer(1),
+		Replicas:   util.IntPointer(0),
 		Envs:       envs,
 		Image:      &service.Image,
 		Visibility: visibility,

--- a/internal/model/server.go
+++ b/internal/model/server.go
@@ -1,0 +1,85 @@
+package model
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/spf13/viper"
+)
+
+type Server struct {
+	Addr              string
+	codeChannel       chan *AuthSession
+	authenticateHTML  string
+	authenticatedHTML string
+}
+
+func NewServer(addr string, authenticateHTML string, authenticatedHTML string) *Server {
+	authHTML, err := NewTemplate(viper.GetString("keycloak-host"), viper.GetString("keycloak-realm"), viper.GetString("client-id")).Replace(authenticateHTML)
+	if err != nil {
+		log.Fatal("could not replace html template varaibles")
+		return nil
+	}
+	return &Server{
+		Addr:              addr,
+		codeChannel:       make(chan *AuthSession),
+		authenticateHTML:  authHTML,
+		authenticatedHTML: authenticatedHTML,
+	}
+}
+
+func (s *Server) Start() (*AuthSession, error) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleRoot)
+	mux.HandleFunc("/auth", s.handleAuth)
+
+	server := &http.Server{
+		Addr:    s.Addr,
+		Handler: mux,
+	}
+
+	go func() {
+		log.Infof("Starting server on %s\n", s.Addr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server error: %v\n", err)
+		}
+	}()
+
+	select {
+	case code := <-s.codeChannel:
+		return code, nil
+	case <-time.After(5 * time.Minute):
+		return nil, fmt.Errorf("timeout waiting for authorization code")
+	}
+}
+
+func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, s.authenticateHTML)
+}
+
+func (s *Server) handleAuth(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	token := r.URL.Query().Get("token")
+	expires_in, err := strconv.Atoi(r.URL.Query().Get("expires_in"))
+	if err != nil {
+		expires_in = 0
+	}
+	refresh_token := r.URL.Query().Get("refresh_token")
+	now := time.Now()
+	if token != "" && id != "" {
+		s.codeChannel <- &AuthSession{
+			SessionStart: &now,
+			Token:        token,
+			RefreshToken: refresh_token,
+			ExpiresIn:    expires_in,
+			SessionId:    &id,
+		}
+		fmt.Fprintln(w, s.authenticatedHTML)
+		return
+	}
+	fmt.Fprintln(w, "Failed to get authorization code.")
+}

--- a/internal/model/template.go
+++ b/internal/model/template.go
@@ -1,0 +1,38 @@
+package model
+
+import (
+	"bytes"
+	"text/template"
+)
+
+type TemplateData struct {
+	BaseURL  string
+	Realm    string
+	ClientID string
+}
+
+func NewTemplate(baseURL string,
+	realm string,
+	clientID string) *TemplateData {
+	return &TemplateData{
+		BaseURL:  baseURL,
+		Realm:    realm,
+		ClientID: clientID,
+	}
+}
+
+func (t *TemplateData) Replace(templateStr string) (string, error) {
+
+	tmpl, err := template.New("script").Parse(templateStr)
+	if err != nil {
+		return "", err
+	}
+
+	var outputBuffer bytes.Buffer
+	err = tmpl.Execute(&outputBuffer, t)
+	if err != nil {
+		return "", err
+	}
+
+	return outputBuffer.String(), nil
+}

--- a/pkg/auth/keycloak.go
+++ b/pkg/auth/keycloak.go
@@ -3,8 +3,6 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"kthcloud-cli/internal/model"
-	"kthcloud-cli/pkg/util"
 
 	"github.com/go-resty/resty/v2"
 	log "github.com/sirupsen/logrus"
@@ -82,28 +80,4 @@ func GetAccessToken(code, clientID, clientSecret, tokenURL, redirectURI string) 
 		return token, nil
 	}
 	return "", fmt.Errorf("failed to get access token from response")
-}
-
-func GetAuthSession(code, clientID, clientSecret, tokenURL, redirectURI string) (*model.AuthSession, error) {
-	client := resty.New()
-	resp, err := client.R().
-		SetFormData(map[string]string{
-			"grant_type":    "authorization_code",
-			"code":          code,
-			"redirect_uri":  redirectURI,
-			"client_id":     clientID,
-			"client_secret": clientSecret,
-		}).
-		Post(tokenURL)
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to get access token: %w", err)
-	}
-
-	KeycloakSession, err := util.ProcessResponse[model.KeycloakSession](string(resp.Body()))
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse auth session response: %w", err)
-	}
-
-	return KeycloakSession.ToAuthSession(), nil
 }

--- a/pkg/auth/static/authenticate.html
+++ b/pkg/auth/static/authenticate.html
@@ -78,7 +78,7 @@
           const payload = decodeJWT(JWT);
           const refresh_token = sessionStorage.getItem("refresh_token");
           const expires_in = sessionStorage.getItem("expires_in")
-          const url = `http://localhost:3000/auth?id=${payload.sub}&token=${token}&expires_in=${expires_in}&refresh_token=${refresh_token}`;
+          const url = `${location.protocol}//${location.host}/auth?id=${payload.sub}&token=${token}&expires_in=${expires_in}&refresh_token=${refresh_token}`;
           window.location.href = url;
           return;
         }

--- a/pkg/auth/static/authenticate.html
+++ b/pkg/auth/static/authenticate.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Authenticate</title>
+  </head>
+  <body style="background-color: #333; color: #ccc; margin: auto; max-width: 800px;">
+    <script>
+      const baseUrl = "{{.BaseURL}}";
+      const realm = "{{.Realm}}";
+      const client_id = "{{.ClientID}}";
+      const redirect_uri = `${location.protocol}//${location.host}/`;
+      const generateRandomState = () => {
+        return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
+          /[xy]/g,
+          function (c) {
+            var r = (Math.random() * 16) | 0,
+              v = c == "x" ? r : (r & 0x3) | 0x8;
+            return v.toString(16);
+          }
+        );
+      };
+      const redirectToKeycloak = () => {
+        const state = generateRandomState();
+        const nonce = generateRandomState();
+        const urlParams = {
+          client_id,
+          redirect_uri,
+          response_type: "code",
+          response_mode: "fragment",
+          scope: "openid",
+          nonce,
+          state,
+        };
+        const conectionURI = new URL(
+          `${baseUrl}/realms/${realm}/protocol/openid-connect/auth`
+        );
+        for (const key of Object.keys(urlParams)) {
+          conectionURI.searchParams.append(key, urlParams[key]);
+        }
+        window.location.href = conectionURI;
+      };
+      const getToken = async (code) => {
+        const tokenUri = new URL(
+          `${baseUrl}/realms/${realm}/protocol/openid-connect/token`
+        );
+        var body = new URLSearchParams();
+        body.append("client_id", client_id);
+        body.append("redirect_uri", redirect_uri);
+        body.append("grant_type", "authorization_code");
+        body.append("code", code);
+        const data = await fetch(tokenUri, {
+          method: "post",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body,
+        });
+        const jsonData = await data.json();
+        sessionStorage.setItem("token", jsonData.access_token);
+        sessionStorage.setItem("expires_in", jsonData.expires_in);
+        sessionStorage.setItem("id_token", jsonData.id_token);
+        sessionStorage.setItem("refresh_token", jsonData.refresh_token);
+        sessionStorage.setItem("session_state", jsonData.session_state);
+        history.replaceState({}, "", "/");
+        location.reload();
+      };
+      const decodeJWT = (token) => {
+        const parts = token.split(".");
+        if (parts.length !== 3) throw new Error("Invalid JWT");
+        const decoded = atob(parts[1]);
+        const payload = JSON.parse(decoded);
+        return payload;
+      };
+      window.addEventListener("load", () => {
+        const token = sessionStorage.getItem("token");
+        if (token !== null) {
+          const JWT = sessionStorage.getItem("token");
+          const payload = decodeJWT(JWT);
+          const refresh_token = sessionStorage.getItem("refresh_token");
+          const expires_in = sessionStorage.getItem("expires_in")
+          const url = `http://localhost:3000/auth?id=${payload.sub}&token=${token}&expires_in=${expires_in}&refresh_token=${refresh_token}`;
+          window.location.href = url;
+          return;
+        }
+        const params = new URLSearchParams(window.location.hash.split("#")[1]);
+        const code = params.get("code");
+        if (code) {
+          sessionStorage.setItem("code", code);
+          getToken(code);
+          return;
+        }
+        redirectToKeycloak();
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Get and parse the token in the browser and then send the info to the local  server, including users id.
When user id is accessible now, the fetchuser fetches the user with the specific id.

closes: #11 
