### PR TITLE
Fix url for update, sed command had changed it

### DIFF
--- a/internal/update/release.go
+++ b/internal/update/release.go
@@ -48,7 +48,7 @@ func (r *GitHubRelease) IsNewer() (bool, error) {
 }
 
 func GetLatestRelease() (*GitHubRelease, error) {
-	url := "https://api.github.com/repos/Phillezi/github.com/Phillezi/kthcloud-cli/releases/latest"
+	url := "https://api.github.com/repos/Phillezi/kthcloud-cli/releases/latest"
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching release info: %v", err)


### PR DESCRIPTION
I changed the module name previously with `sed` (didnt want to replace all occurances manually) but it had changed the url.