### PR TITLE
Added support for build in compose files

### DIFF
--- a/cmd/cli_compose.go
+++ b/cmd/cli_compose.go
@@ -26,7 +26,13 @@ var composeUpCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		detached, _ := cmd.Flags().GetBool("detached")
 		tryToCreateVolumes, _ := cmd.Flags().GetBool("try-volumes")
-		compose.Up(detached, tryToCreateVolumes)
+		servicesToBuild, _ := cmd.Flags().GetStringSlice("build")
+		nonInteractive, _ := cmd.Flags().GetBool("non-interactive")
+		buildAll := false
+		if servicesToBuild != nil && len(servicesToBuild) == 0 && false {
+			buildAll = true
+		}
+		compose.Up(detached, tryToCreateVolumes, buildAll, nonInteractive, servicesToBuild)
 	},
 }
 var composeDownCmd = &cobra.Command{
@@ -60,6 +66,10 @@ func init() {
 	composeUpCmd.Flags().BoolP("try-volumes", "", false, "Try uploading local files and dirs that should be mounted on the deployment.\nIf enabled it will \"steal\" cookies from your browser to authenticate.")
 	composeUpCmd.Flags().BoolP("detached", "d", false, "Run detached, default behaviour attaches logs from the deployments.")
 	viper.BindPFlag("detached", composeUpCmd.Flags().Lookup("detached"))
+
+	composeUpCmd.Flags().Bool("non-interactive", false, "Yes to all options and run non interactively")
+
+	composeUpCmd.Flags().StringSlice("build", nil, "Build services and push to registry, can be followed by service name to specify which should be built")
 
 	// Register subcommands with the main compose command
 	composeCmd.AddCommand(composeParseCmd)

--- a/cmd/cli_compose.go
+++ b/cmd/cli_compose.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/Phillezi/kthcloud-cli/pkg/v1/commands/compose"
 	"github.com/Phillezi/kthcloud-cli/pkg/v1/commands/compose/storage"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -29,7 +30,8 @@ var composeUpCmd = &cobra.Command{
 		servicesToBuild, _ := cmd.Flags().GetStringSlice("build")
 		nonInteractive, _ := cmd.Flags().GetBool("non-interactive")
 		buildAll := false
-		if servicesToBuild != nil && len(servicesToBuild) == 0 && false {
+		if len(servicesToBuild) == 1 && servicesToBuild[0] == "__all__" {
+			logrus.Debugln("build all is set")
 			buildAll = true
 		}
 		compose.Up(detached, tryToCreateVolumes, buildAll, nonInteractive, servicesToBuild)
@@ -70,6 +72,8 @@ func init() {
 	composeUpCmd.Flags().Bool("non-interactive", false, "Yes to all options and run non interactively")
 
 	composeUpCmd.Flags().StringSlice("build", nil, "Build services and push to registry, can be followed by service name to specify which should be built")
+	buildF := composeUpCmd.Flags().Lookup("build")
+	buildF.NoOptDefVal = "__all__"
 
 	// Register subcommands with the main compose command
 	composeCmd.AddCommand(composeParseCmd)

--- a/pkg/progress/spinner/logrusHook.go
+++ b/pkg/progress/spinner/logrusHook.go
@@ -1,0 +1,42 @@
+package spinner
+
+import (
+	"sync"
+
+	"github.com/briandowns/spinner"
+	"github.com/sirupsen/logrus"
+)
+
+type SpinnerHook struct {
+	spinner *spinner.Spinner
+	mu      sync.Mutex
+}
+
+func NewSpinnerHook(spinner *spinner.Spinner) *SpinnerHook {
+	return &SpinnerHook{
+		spinner: spinner,
+	}
+}
+
+func (h *SpinnerHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *SpinnerHook) Fire(entry *logrus.Entry) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.spinner != nil {
+		h.spinner.Stop()
+	}
+
+	if h.spinner != nil && h.spinner.Enabled() {
+		h.spinner.Start()
+		/*go func() {
+			time.Sleep(100 * time.Millisecond)
+			h.spinner.Start()
+		}()*/
+	}
+
+	return nil
+}

--- a/pkg/scheduler/sched.go
+++ b/pkg/scheduler/sched.go
@@ -207,7 +207,7 @@ func (s *Sched) startJob(runnable *Job, onDone chan *Job) {
 			job.mu.Unlock()
 			job.CancelCallback()
 		}); err != nil {
-			logrus.Debugln("Error occurred on job with id: " + runnable.ID)
+			logrus.Debugln("Error occurred on job with id: "+runnable.ID, "err:", err)
 			job.mu.Lock()
 			job.State = Errored
 			job.mu.Unlock()

--- a/pkg/util/conv.go
+++ b/pkg/util/conv.go
@@ -32,3 +32,29 @@ func ProcessResponse[T any](responseBody string) (*T, error) {
 
 	return &item, nil
 }
+
+func DeploymentCreateToUpdate(create *body.DeploymentCreate) body.DeploymentUpdate {
+
+	return body.DeploymentUpdate{
+		// skipping name here
+		CpuCores:        create.CpuCores,
+		RAM:             create.RAM,
+		Replicas:        create.Replicas,
+		Envs:            toPointerSlice(create.Envs),
+		Volumes:         toPointerSlice(create.Volumes),
+		InitCommands:    toPointerSlice(create.InitCommands),
+		Args:            toPointerSlice(create.Args),
+		Visibility:      &create.Visibility,
+		Private:         &create.Private,
+		Image:           create.Image,
+		HealthCheckPath: create.HealthCheckPath,
+		CustomDomain:    create.CustomDomain,
+	}
+}
+
+func toPointerSlice[T any](slice []T) *[]T {
+	if len(slice) == 0 {
+		return nil
+	}
+	return &slice
+}

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -49,3 +49,14 @@ func EnsureFileExists(path string) error {
 	}
 	return nil
 }
+
+func FileExists(path string) (bool, error) {
+	var err error
+	if _, err = os.Stat(path); os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/v1/auth/client/exists.go
+++ b/pkg/v1/auth/client/exists.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"go-deploy/dto/v2/body"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -19,4 +21,44 @@ func (c *Client) DeploymentExists(id string) bool {
 	}
 
 	return true
+}
+
+func (c *Client) DeploymentExistsByName(name string) (bool, string) {
+	for try := 0; try < 2; try++ {
+		depls, err := c.Deployments()
+		if err != nil {
+			logrus.Errorln("error occurred when trying to get deployments", err)
+			return false, ""
+		}
+		for _, depl := range depls {
+			if depl.Name == name {
+				return true, depl.ID
+			}
+		}
+		logrus.Debugln("deployment with name:", name, ". Not found, dropping cache and trying again to ensure this")
+		c.DropDeploymentsCache()
+	}
+	return false, ""
+}
+
+// returns existsWithSameName, idOfDeploymentWithTheName, matchesFilter
+func (c *Client) DeploymentExistsByNameWFilter(name string, filter func(depl body.DeploymentRead) bool) (bool, string, bool) {
+	for try := 0; try < 2; try++ {
+		depls, err := c.Deployments()
+		if err != nil {
+			logrus.Errorln("error occurred when trying to get deployments", err)
+			return false, "", false
+		}
+		for _, depl := range depls {
+			if depl.Name == name && filter(depl) {
+				return true, depl.ID, false
+			} else if depl.Name == name {
+				// depl with the same name exists but it doesnt match the filter
+				return true, depl.ID, false
+			}
+		}
+		logrus.Debugln("deployment with name:", name, ". Not found, dropping cache and trying again to ensure this")
+		c.DropDeploymentsCache()
+	}
+	return false, "", false
 }

--- a/pkg/v1/auth/client/exists.go
+++ b/pkg/v1/auth/client/exists.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+func (c *Client) DeploymentExists(id string) bool {
+
+	resp, err := c.client.R().
+		Get(c.baseURL + "/v2/deployments/" + id)
+
+	if err != nil {
+		logrus.Errorln("error checking if deployment with id", id, "exists:", err)
+		return false
+	}
+
+	if resp.StatusCode() == 404 {
+		return false
+	}
+
+	return true
+}

--- a/pkg/v1/auth/client/remove.go
+++ b/pkg/v1/auth/client/remove.go
@@ -5,6 +5,7 @@ import (
 	"go-deploy/dto/v2/body"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/sirupsen/logrus"
 )
 
 func (c *Client) Remove(data any) (*resty.Response, error) {
@@ -19,6 +20,7 @@ func (c *Client) Remove(data any) (*resty.Response, error) {
 		return nil, fmt.Errorf("unsupported data type: %T", v)
 	}
 
+	logrus.Debugln("removing deployment:", path)
 	resp, err := c.client.R().
 		SetHeader("Content-Type", "application/json").
 		Delete(c.baseURL + path)

--- a/pkg/v1/auth/client/update.go
+++ b/pkg/v1/auth/client/update.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"go-deploy/dto/v2/body"
+
+	"github.com/go-resty/resty/v2"
+)
+
+func (c *Client) Update(data any, id string) (*resty.Response, error) {
+	var path string
+
+	switch v := data.(type) {
+	case *body.DeploymentUpdate:
+		path = "/v2/deployments/" + id
+	case *body.VmUpdate:
+		path = "/v2/vms/" + id
+	default:
+		return nil, fmt.Errorf("unsupported data type: %T", v)
+	}
+
+	body, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal data to JSON: %v", err)
+	}
+
+	resp, err := c.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(bytes.NewReader(body)).
+		Post(c.baseURL + path)
+
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %v", err)
+	}
+
+	return resp, nil
+}

--- a/pkg/v1/commands/build/build.go
+++ b/pkg/v1/commands/build/build.go
@@ -66,10 +66,13 @@ func buildPush(tag, dockerfile, context string) error {
 	}
 
 	if dockerfile != "" {
-		cmdParts = append(cmdParts, "--dockerfile="+dockerfile)
+		dockerfilePath := path.Join(context, dockerfile)
+		logrus.Debugln("using dockerfile:", dockerfilePath)
+		cmdParts = append(cmdParts, "--file="+dockerfilePath)
 	}
 
 	if context != "" {
+		logrus.Debugln("using context:", context)
 		cmdParts = append(cmdParts, context)
 	} else {
 		cmdParts = append(cmdParts, ".")

--- a/pkg/v1/commands/build/build.go
+++ b/pkg/v1/commands/build/build.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Build() {
-	if _, err := hasDockerCommands(); err != nil {
+	if _, err := HasDockerCommands(); err != nil {
 		logrus.Fatal(err)
 	}
 
@@ -44,7 +44,7 @@ func Build() {
 		return
 	}
 
-	err = runBuildPushCommands(username, password, tag)
+	err = RunBuildPushCommands(username, password, tag, "", "")
 	if err != nil {
 		logrus.Fatal("Error running build and push command:", err)
 		return
@@ -60,8 +60,22 @@ func loginToRegistry(registry, username, password string) error {
 	return cmd.Run()
 }
 
-func buildPush(tag string) error {
-	cmd := exec.Command("docker", "buildx", "build", "--platform=linux/amd64", "--tag="+tag, "--push", ".")
+func buildPush(tag, dockerfile, context string) error {
+	cmdParts := []string{
+		"buildx", "build", "--platform=linux/amd64", "--tag=" + tag, "--push",
+	}
+
+	if dockerfile != "" {
+		cmdParts = append(cmdParts, "--dockerfile="+dockerfile)
+	}
+
+	if context != "" {
+		cmdParts = append(cmdParts, context)
+	} else {
+		cmdParts = append(cmdParts, ".")
+	}
+
+	cmd := exec.Command("docker", cmdParts...)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -69,15 +83,15 @@ func buildPush(tag string) error {
 	return cmd.Run()
 }
 
-func runBuildPushCommands(username, password, tag string) error {
+func RunBuildPushCommands(username, password, tag, dockerfile, context string) error {
 	registry := strings.Split(tag, "/")[0]
 	if err := loginToRegistry(registry, username, password); err != nil {
 		return err
 	}
-	return buildPush(tag)
+	return buildPush(tag, dockerfile, context)
 }
 
-func hasDockerCommands() (bool, error) {
+func HasDockerCommands() (bool, error) {
 	if _, err := exec.LookPath("docker"); err != nil {
 		return false, fmt.Errorf("docker is not installed or not in PATH")
 	}

--- a/pkg/v1/commands/cicd/create.go
+++ b/pkg/v1/commands/cicd/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/Phillezi/kthcloud-cli/pkg/v1/auth/client"
 	"github.com/sirupsen/logrus"
@@ -11,7 +12,7 @@ import (
 )
 
 func Create(rootdir string, createWF bool, name string) {
-	gitDir, _, err := GetGitRepoInfoFrom(rootdir)
+	gitDir, upstreamURL, err := GetGitRepoInfoFrom(rootdir)
 	if err != nil {
 		gitDir = rootdir
 	}
@@ -61,6 +62,12 @@ func Create(rootdir string, createWF bool, name string) {
 		return
 	}
 
+	username, password, tag, err := ExtractSecrets(conf)
+	if err != nil {
+		logrus.Fatal("Error when trying remove secrets from workflow", err)
+		return
+	}
+
 	yamlConf, err := yaml.Marshal(conf)
 	if err != nil {
 		logrus.Fatalf("error marshalling YAML: %v", err)
@@ -78,5 +85,9 @@ func Create(rootdir string, createWF bool, name string) {
 	if err != nil {
 		logrus.Fatal("Error when trying save cicd config", err)
 		return
+	}
+
+	if strings.Contains(upstreamURL, "github.com") {
+		promptUserAddSecrets(upstreamURL, username, password, tag)
 	}
 }

--- a/pkg/v1/commands/cicd/create.go
+++ b/pkg/v1/commands/cicd/create.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/Phillezi/kthcloud-cli/pkg/util"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
@@ -22,11 +21,6 @@ func Create(rootdir string, createWF bool, name string) {
 	var id string
 
 	if !FileExists(repoConfDir, "DEPLOYMENT") {
-		name, err := util.GetNameFromUser()
-		if err != nil {
-			logrus.Fatal("Error when getting name from user:", err)
-			return
-		}
 		id, err = createDeployment(context.Background(), name)
 		if err != nil {
 			logrus.Fatal("Error when creating empty deployment:", err)

--- a/pkg/v1/commands/cicd/create.go
+++ b/pkg/v1/commands/cicd/create.go
@@ -1,0 +1,79 @@
+package cicd
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/Phillezi/kthcloud-cli/pkg/util"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+func Create(rootdir string, createWF bool, name string) {
+	gitDir, _, err := GetGitRepoInfoFrom(rootdir)
+	if err != nil {
+		gitDir = rootdir
+	}
+	repoConfDir := path.Join(rootdir, ".kthcloud")
+	ghConfDir := path.Join(gitDir, ".github")
+	wfConfDir := path.Join(ghConfDir, "workflows")
+
+	var id string
+
+	if !FileExists(repoConfDir, "DEPLOYMENT") {
+		name, err := util.GetNameFromUser()
+		if err != nil {
+			logrus.Fatal("Error when getting name from user:", err)
+			return
+		}
+		id, err = createDeployment(context.Background(), name)
+		if err != nil {
+			logrus.Fatal("Error when creating empty deployment:", err)
+			return
+		}
+	} else {
+		id, err = ReadFile(repoConfDir, "DEPLOYMENT")
+		if err != nil {
+			logrus.Fatal("Error when trying to get deployment id", err)
+			return
+		}
+	}
+
+	if id != "" {
+		err = CreateFile(repoConfDir, "DEPLOYMENT", id)
+		if err != nil {
+			logrus.Fatal("Error when trying to save deployment id", err)
+			return
+		}
+	}
+
+	if !createWF {
+		return
+	}
+
+	conf, err := GetGHACIConf(id)
+	if err != nil {
+		logrus.Fatal("Error when getting CI config:", err)
+		return
+	}
+
+	yamlConf, err := yaml.Marshal(conf)
+	if err != nil {
+		logrus.Fatalf("error marshalling YAML: %v", err)
+		return
+	}
+	filename := "kthcloud.yml"
+	if name != "" {
+		filename = "kthcloud-" + name + "-cicd.yml"
+	}
+	for i := 0; FileExists(wfConfDir, filename); i++ {
+		filename = fmt.Sprintf("kthcloud-%s-cicd-%d.yml", name, i)
+	}
+
+	err = CreateFile(wfConfDir, filename, string(yamlConf))
+	if err != nil {
+		logrus.Fatal("Error when trying save cicd config", err)
+		return
+	}
+}

--- a/pkg/v1/commands/cicd/create.go
+++ b/pkg/v1/commands/cicd/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/Phillezi/kthcloud-cli/pkg/v1/auth/client"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
@@ -31,6 +32,14 @@ func Create(rootdir string, createWF bool, name string) {
 		if err != nil {
 			logrus.Fatal("Error when trying to get deployment id", err)
 			return
+		}
+		if !client.Get().DeploymentExists(id) {
+			logrus.Debugln("file exists but contains ID of deployment that doesnt")
+			id, err = createDeployment(context.Background(), name)
+			if err != nil {
+				logrus.Fatal("Error when creating empty deployment:", err)
+				return
+			}
 		}
 	}
 

--- a/pkg/v1/commands/cicd/git.go
+++ b/pkg/v1/commands/cicd/git.go
@@ -8,9 +8,14 @@ import (
 )
 
 func GetGitRepoInfo() (repoRoot string, upstreamURL string, err error) {
+	path, _ := os.Getwd()
 
+	return GetGitRepoInfoFrom(path)
+}
+
+func GetGitRepoInfoFrom(path string) (repoRoot string, upstreamURL string, err error) {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	cmd.Dir, _ = os.Getwd()
+	cmd.Dir = path
 	repoRootBytes, err := cmd.Output()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get repo root: %v", err)

--- a/pkg/v1/commands/compose/builder/builder.go
+++ b/pkg/v1/commands/compose/builder/builder.go
@@ -3,11 +3,15 @@ package builder
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path"
 
 	"github.com/Phillezi/kthcloud-cli/internal/update"
+	"github.com/Phillezi/kthcloud-cli/pkg/v1/auth/client"
 	"github.com/Phillezi/kthcloud-cli/pkg/v1/commands/build"
 	"github.com/Phillezi/kthcloud-cli/pkg/v1/commands/cicd"
 	"github.com/Phillezi/kthcloud-cli/pkg/v1/models/service"
+	"github.com/sirupsen/logrus"
 )
 
 // build a service
@@ -20,21 +24,41 @@ func Build(serviceName string, service *service.Service, yesToAll bool) error {
 		return errors.New("no build config present")
 	}
 
-	deploymentID, err := getCICDDeploymentID(service.Build.Context, func(baseDir string) {
-		if !yesToAll {
-			yesBuild, _ := update.PromptYesNo("No existing deployment specified in " + baseDir + "/.kthcloud/DEPLOYMENT" + "\nDo you wish to create a cicd deployment for " + serviceName + "?")
-			if !yesBuild {
-				fmt.Println("Ok, wont build " + serviceName)
-				return
+	exists := false
+	deploymentID := ""
+
+	for !exists {
+		onCicdNotConfigured := func(baseDir string) {
+			if !cicd.FileExists(baseDir, ".") {
+				logrus.Warnln("Build context specifies a directory that doesnt exist:", baseDir)
 			}
-			yesAddWorkflow, _ := update.PromptYesNo("Do you want to add a Github workflow for CICD on " + serviceName + "?")
-			cicd.Create(baseDir, yesAddWorkflow, serviceName)
-		} else {
-			cicd.Create(baseDir, true, serviceName)
+			if !yesToAll {
+				yesBuild, _ := update.PromptYesNo("No existing deployment specified in " + baseDir + "/.kthcloud/DEPLOYMENT" + "\nDo you wish to create a cicd deployment for " + serviceName + "?")
+				if !yesBuild {
+					fmt.Println("Ok, wont build " + serviceName)
+					return
+				}
+				yesAddWorkflow, _ := update.PromptYesNo("Do you want to add a Github workflow for CICD on " + serviceName + "?")
+				cicd.Create(baseDir, yesAddWorkflow, serviceName)
+			} else {
+				cicd.Create(baseDir, true, serviceName)
+			}
 		}
-	})
-	if err != nil {
-		return err
+		deploymentID, err := GetCICDDeploymentID(service.Build.Context, onCicdNotConfigured)
+		if err != nil {
+			return err
+		}
+
+		if exists = client.Get().DeploymentExists(deploymentID); !exists {
+			logrus.Errorln("cicd deployment specified in .kthcloud dir doesnt exist")
+			contextPath := service.Build.Context
+			if contextPath == "" {
+				contextPath = "."
+			}
+			wd, _ := os.Getwd()
+			fullpath := path.Join(wd, contextPath)
+			onCicdNotConfigured(fullpath)
+		}
 	}
 
 	conf, err := cicd.GetGHACIConf(deploymentID)
@@ -47,10 +71,12 @@ func Build(serviceName string, service *service.Service, yesToAll bool) error {
 		return err
 	}
 
+	logrus.Debugln("starting build and push of", tag)
 	err = build.RunBuildPushCommands(username, password, tag, service.Build.Dockerfile, service.Build.Context)
 	if err != nil {
 		return err
 	}
+	logrus.Debugln("done with build and push of", tag)
 
 	return nil
 }

--- a/pkg/v1/commands/compose/builder/builder.go
+++ b/pkg/v1/commands/compose/builder/builder.go
@@ -1,0 +1,56 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Phillezi/kthcloud-cli/internal/update"
+	"github.com/Phillezi/kthcloud-cli/pkg/v1/commands/build"
+	"github.com/Phillezi/kthcloud-cli/pkg/v1/commands/cicd"
+	"github.com/Phillezi/kthcloud-cli/pkg/v1/models/service"
+)
+
+// build a service
+func Build(serviceName string, service *service.Service, yesToAll bool) error {
+	if _, err := build.HasDockerCommands(); err != nil {
+		return err
+	}
+
+	if service.Build == nil {
+		return errors.New("no build config present")
+	}
+
+	deploymentID, err := getCICDDeploymentID(service.Build.Context, func(baseDir string) {
+		if !yesToAll {
+			yesBuild, _ := update.PromptYesNo("No existing deployment specified in " + baseDir + "/.kthcloud/DEPLOYMENT" + "\nDo you wish to create a cicd deployment for " + serviceName + "?")
+			if !yesBuild {
+				fmt.Println("Ok, wont build " + serviceName)
+				return
+			}
+			yesAddWorkflow, _ := update.PromptYesNo("Do you want to add a Github workflow for CICD on " + serviceName + "?")
+			cicd.Create(baseDir, yesAddWorkflow, serviceName)
+		} else {
+			cicd.Create(baseDir, true, serviceName)
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	conf, err := cicd.GetGHACIConf(deploymentID)
+	if err != nil {
+		return err
+	}
+
+	username, password, tag, err := cicd.ExtractSecrets(conf)
+	if err != nil {
+		return err
+	}
+
+	err = build.RunBuildPushCommands(username, password, tag, service.Build.Dockerfile, service.Build.Context)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/v1/commands/compose/builder/lookup.go
+++ b/pkg/v1/commands/compose/builder/lookup.go
@@ -1,0 +1,46 @@
+package builder
+
+import (
+	"errors"
+	"os"
+	"path"
+
+	"github.com/Phillezi/kthcloud-cli/pkg/util"
+)
+
+func getCICDDeploymentID(contextPath string, onDeplNotCICDConfigured func(baseDir string)) (string, error) {
+	if contextPath == "" {
+		contextPath = "."
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	fullpath := path.Join(wd, contextPath)
+	if fullpath == "" {
+		// will probably never happen
+		return "", errors.New("fullcontextpath is empty")
+	}
+	medadataDir := fullpath + "/.kthcloud"
+	var deplfileExists bool
+	callbackCalls := 0 // could be bool but might want retries?
+	for !deplfileExists {
+		if callbackCalls >= 1 {
+			return "", errors.New("max callback calls reached but cicd config still doesnt exist")
+		}
+		deplfileExists, err = util.FileExists(medadataDir + "/DEPLOYMENT")
+		if err != nil {
+			return "", err
+		}
+		if !deplfileExists {
+			// id file doesnt exist call the callback to handle it
+			onDeplNotCICDConfigured(fullpath)
+			callbackCalls++
+		}
+	}
+	content, err := os.ReadFile(medadataDir + "/DEPLOYMENT")
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}

--- a/pkg/v1/commands/compose/builder/lookup.go
+++ b/pkg/v1/commands/compose/builder/lookup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Phillezi/kthcloud-cli/pkg/util"
 )
 
-func getCICDDeploymentID(contextPath string, onDeplNotCICDConfigured func(baseDir string)) (string, error) {
+func GetCICDDeploymentID(contextPath string, onDeplNotCICDConfigured func(baseDir string)) (string, error) {
 	if contextPath == "" {
 		contextPath = "."
 	}
@@ -24,6 +24,7 @@ func getCICDDeploymentID(contextPath string, onDeplNotCICDConfigured func(baseDi
 	medadataDir := fullpath + "/.kthcloud"
 	var deplfileExists bool
 	callbackCalls := 0 // could be bool but might want retries?
+
 	for !deplfileExists {
 		if callbackCalls >= 1 {
 			return "", errors.New("max callback calls reached but cicd config still doesnt exist")
@@ -33,6 +34,9 @@ func getCICDDeploymentID(contextPath string, onDeplNotCICDConfigured func(baseDi
 			return "", err
 		}
 		if !deplfileExists {
+			if onDeplNotCICDConfigured == nil {
+				return "", err
+			}
 			// id file doesnt exist call the callback to handle it
 			onDeplNotCICDConfigured(fullpath)
 			callbackCalls++

--- a/pkg/v1/commands/compose/builder/registry.go
+++ b/pkg/v1/commands/compose/builder/registry.go
@@ -1,0 +1,92 @@
+package builder
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/Phillezi/kthcloud-cli/pkg/v1/commands/cicd"
+	"github.com/Phillezi/kthcloud-cli/pkg/v1/models/compose"
+)
+
+func GetBuildsRequired(compose compose.Compose) map[string]bool {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	needsRebuildMap := make(map[string]bool)
+	for name, service := range compose.Services {
+		if service.Build != nil {
+			id, err := getCICDDeploymentID(service.Build.Context, func(baseDir string) {})
+			if err != nil {
+				mu.Lock()
+				needsRebuildMap[name] = true
+				mu.Unlock()
+				continue
+			}
+			conf, err := cicd.GetGHACIConf(id)
+			username, password, tag, err := cicd.ExtractSecrets(conf)
+			wg.Add(1)
+			go HasDockerImage(username, password, tag, func() {
+				mu.Lock()
+				needsRebuildMap[name] = true
+				mu.Unlock()
+				wg.Done()
+			})
+
+		}
+	}
+
+	wg.Wait()
+	return needsRebuildMap
+}
+
+// tag contains the registry
+func HasDockerImage(username, password, tag string, onNotExists func()) (bool, error) {
+	parts := strings.Split(tag, "/")
+	if len(parts) < 2 {
+		return false, fmt.Errorf("invalid tag format: %s", tag)
+	}
+
+	registry := parts[0]
+	repoAndTag := strings.Join(parts[1:], "/")
+
+	repoParts := strings.SplitN(repoAndTag, ":", 2)
+	if len(repoParts) != 2 {
+		return false, fmt.Errorf("tag must include an image and tag (e.g., repository/image:tag): %s", repoAndTag)
+	}
+
+	repository := repoParts[0]
+	imageTag := repoParts[1]
+
+	url := fmt.Sprintf("https://%s/v2/%s/manifests/%s", registry, repository, imageTag)
+
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	if username != "" && password != "" {
+		req.SetBasicAuth(username, password)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to contact registry: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	} else if resp.StatusCode == http.StatusNotFound {
+		if onNotExists != nil {
+			onNotExists()
+		}
+		return false, nil
+	} else {
+		var errorMessage map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&errorMessage)
+		return false, fmt.Errorf("unexpected response from registry: %s (%d) - %v", resp.Status, resp.StatusCode, errorMessage)
+	}
+}

--- a/pkg/v1/commands/compose/down.go
+++ b/pkg/v1/commands/compose/down.go
@@ -35,12 +35,6 @@ func Down() {
 		deploymentMap[depl.Name] = &depl
 	}
 
-	for name := range composeInstance.Services {
-		if depl, exists := deploymentMap[name]; exists {
-			c.Remove(depl)
-		}
-	}
-
 	var wg sync.WaitGroup
 
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
@@ -50,6 +44,10 @@ func Down() {
 
 	for name := range composeInstance.Services {
 		if deployment, exists := deploymentMap[name]; exists {
+			if deployment.Image == nil {
+				logrus.Infoln("Skipping deletion of deployment:", deployment.Name, ". Since it is a custom deployment (cicd)")
+				continue
+			}
 			resp, err := c.Remove(deployment)
 			if err != nil {
 				logrus.Fatal(err)

--- a/pkg/v1/commands/compose/jobs/log.go
+++ b/pkg/v1/commands/compose/jobs/log.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	hook "github.com/Phillezi/kthcloud-cli/pkg/progress/spinner"
 	"github.com/Phillezi/kthcloud-cli/pkg/scheduler"
 	"github.com/briandowns/spinner"
 	"github.com/sirupsen/logrus"
@@ -12,6 +13,8 @@ import (
 func MonitorJobStates(jobIDs map[string]string, sched *scheduler.Sched, spinner *spinner.Spinner) error {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
+
+	logrus.AddHook(hook.NewSpinnerHook(spinner))
 
 	for {
 		select {

--- a/pkg/v1/commands/compose/jobs/log.go
+++ b/pkg/v1/commands/compose/jobs/log.go
@@ -13,6 +13,7 @@ import (
 func MonitorJobStates(jobIDs map[string]string, sched *scheduler.Sched, spinner *spinner.Spinner) error {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
+	defer spinner.Disable()
 
 	logrus.AddHook(hook.NewSpinnerHook(spinner))
 

--- a/pkg/v1/commands/compose/up.go
+++ b/pkg/v1/commands/compose/up.go
@@ -106,7 +106,10 @@ func Up(detached, tryToCreateVolumes, buildAll, nonInteractive bool, servicesToB
 		}
 	}
 
-	buildsReq := builder.GetBuildsRequired(*composeInstance)
+	buildsReq, err := builder.GetBuildsRequired(*composeInstance)
+	if err != nil {
+		logrus.Fatalln("Error getting builds required:", err)
+	}
 	for n, needsBuild := range buildsReq {
 		if needsBuild {
 			if err := builder.Build(n, composeInstance.Services[n], nonInteractive); err != nil {

--- a/pkg/v1/models/service/build.go
+++ b/pkg/v1/models/service/build.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Build struct {
+	// context defines either a path to a directory containing a Dockerfile, or a URL to a git repository.
+	// When the value supplied is a relative path, it is interpreted as relative to the project directory.
+	// If not set explicitly, context defaults to project directory (.).
+	Context string `yaml:"context,omitempty"`
+	// The name of the dockerfile to use inside the context directory (can be relative path to the context directory).
+	Dockerfile string `yaml:"dockerfile,omitempty"`
+	// Build args to pass to the dockerfile.
+	Args []string `yaml:"args,omitempty"`
+}
+
+func (b *Build) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		// If the node is a scalar (string), assign it to Raw
+		return value.Decode(&b.Context)
+	} else if value.Kind == yaml.MappingNode {
+		// If the node is a mapping, decode into the struct fields
+		type buildAlias Build // Create an alias to avoid recursion
+		return value.Decode((*buildAlias)(b))
+	}
+	return fmt.Errorf("invalid type for Build: %v", value.Kind)
+}
+func (b Build) String() string {
+	if b.Context != "" && b.Args == nil && b.Dockerfile == "" {
+		return b.Context
+	}
+
+	var sb strings.Builder
+	sb.WriteString("\n")
+	if b.Context != "" {
+		sb.WriteString(fmt.Sprintf("  Context: %s\n", b.Context))
+	}
+	if b.Dockerfile != "" {
+		sb.WriteString(fmt.Sprintf("  Dockerfile: %s\n", b.Dockerfile))
+	}
+	if len(b.Args) > 0 {
+		sb.WriteString(fmt.Sprintf("  Args: %s\n", strings.Join(b.Args, ", ")))
+	}
+
+	return sb.String()
+}

--- a/pkg/v1/models/service/service.go
+++ b/pkg/v1/models/service/service.go
@@ -13,6 +13,7 @@ import (
 
 type Service struct {
 	Image        string   `yaml:"image,omitempty"`
+	Build        *Build   `yaml:"build,omitempty"`
 	Environment  EnvVars  `yaml:"environment,omitempty"`
 	Ports        []string `yaml:"ports,omitempty"`
 	Volumes      []string `yaml:"volumes,omitempty"`
@@ -120,7 +121,13 @@ func (s *Service) ToDeployment(name string, projectDir string) *body.DeploymentC
 func (s *Service) String() string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("  Image: %s\n", s.Image))
+	if s.Image != "" {
+		sb.WriteString(fmt.Sprintf("  Image: %s\n", s.Image))
+	}
+
+	if s.Build != nil {
+		sb.WriteString(fmt.Sprintf("  Build: %s\n", strings.Join(strings.Split(s.Build.String(), "\n"), "\n  ")))
+	}
 
 	if len(s.Environment) > 0 {
 		sb.WriteString("  Environment:\n")

--- a/pkg/v1/models/service/service.go
+++ b/pkg/v1/models/service/service.go
@@ -103,13 +103,19 @@ func (s *Service) ToDeployment(name string, projectDir string) *body.DeploymentC
 		}
 	}
 
+	image := &s.Image
+
+	if s.Build != nil {
+		image = nil
+	}
+
 	return &body.DeploymentCreate{
 		Name:            name,
 		CpuCores:        cores,
 		RAM:             ram,
 		Replicas:        replicas,
 		Envs:            envs,
-		Image:           &s.Image,
+		Image:           image,
 		Visibility:      visibility,
 		Args:            s.Command,
 		Zone:            zone,


### PR DESCRIPTION
The Compose files now support `build`!

This makes it possible to create your own deployments and manage the build and deployment of them in a compose project.

## Usage

If your compose file contains `build` it will be parsed to get the context and dockerfile to build. If the context directory does not contain a `.kthcloud/DEPLOYMENT` containing the id of an existing deployment the CLI will ask the user if they want to create one, and then if they want to create a cicd workflow for gh actions inside the root git directory of the context.

When the cicd deployment is created it will build and push the image to it and then update the deployment to match the docker compose service specification.

If it already contained a `.kthcloud/DEPLOYMENT` containing the id of an existing deployment, it will build and push if:
1. `--build` is specified
2. `--build <servicename>...` (multiple can be specified by comma separation) is specified and `<servicename>` is the name of the service
3. The tag does not exist on the registry

When a user runs `down` on a compose project containing a `custom-deployment` it will not be destroyed, since that would break the cicd pipeline.
